### PR TITLE
Feat/fast evaluation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 # Changelog
 
-*1.0.0 -> 1.0.1*
+*1.0.1 -> 1.0.2*
 
-- Expected variables no longer need to be specified when evaluating an
-expression, since they are deducted from the expression itself
-- Documentation for all modules
-- Fixed `syntax_check` module, which didn't properly check for operators at
-the end of a string.
+- Implemented FastEvaluate function, which calculates the given expression
+without generating an evaluation tree
+- Documentation updated
+- Added a performance analysis in the evaluate module, which compares the
+time the different approaches to evaluation take.

--- a/evaluator.js
+++ b/evaluator.js
@@ -63,7 +63,7 @@ function evaluate(expression) {
     traverse(evaluate_tree, unknowns);
 
     return {
-        evaluate: variables => {
+        calc: variables => {
             if (Object.keys(variables).length !== unknowns.length)
                 throw Error(`Incorrect number of values passed: should be ${unknowns.length} and is ${Object.keys(variables).length}`);
             for (let v of unknowns)
@@ -112,25 +112,43 @@ function fastEvaluate(expression, values) {
 
 module.exports = { evaluate, fastEvaluate };
 
+const { functionsTime } = require('./functions_time.js');
+
 if (!module.parent) {
-    let str = "((x + 5) / (3 - y))";
-    let expression = evaluate(str);
+    
+    if (process.argv.length > 3 && process.argv[2] === 'time') {
+        const times = process.argv[3];
+        let str = '((x + 5) / (3 - y))';
+        let expression = evaluate(str);
 
-    console.log(`Expression: ${str}`);
-    console.log(`Result with x=2 and y=5: ${expression.evaluate({ x: 2, y: 5 })}`);
-    console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2, y: 5 })}`);
+        let time1 = functionsTime(evaluate, times, str);
+        let time2 = functionsTime(expression.calc, times, { x: 2, y: 5 });
+        let time3 = functionsTime(fastEvaluate, times, str, { x: 2, y: 5 });
 
-    str = "(-(-x + 5) / (-3 + y))";
-    expression = evaluate(str);
+        console.log(`Timestamps over ${times} iterations:
+        Evaluation tree generation: ${time1}ms
+        Calculation with tree: ${time2}ms
+        Fast calculation: ${time3}ms`);
+    } else {
+        let str = "((x + 5) / (3 - y))";
+        let expression = evaluate(str);
 
-    console.log(`Expression: ${str}`);
-    console.log(`Result with x=2 and y=5: ${expression.evaluate({ x: 2, y: 5 })}`);
-    console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2, y: 5 })}`);
+        console.log(`Expression: ${str}`);
+        console.log(`Result with x=2 and y=5: ${expression.calc({ x: 2, y: 5 })}`);
+        console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2, y: 5 })}`);
 
-    str = "+4(x + 3x)(-9 - x)";
-    expression = evaluate(str);
+        str = "(-(-x + 5) / (-3 + y))";
+        expression = evaluate(str);
 
-    console.log(`Expression: ${str}`);
-    console.log(`Result with x=2: ${expression.evaluate({ x: 2 })}`);
-    console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2})}`);
+        console.log(`Expression: ${str}`);
+        console.log(`Result with x=2 and y=5: ${expression.calc({ x: 2, y: 5 })}`);
+        console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2, y: 5 })}`);
+
+        str = "+4(x + 3x)(-9 - x)";
+        expression = evaluate(str);
+
+        console.log(`Expression: ${str}`);
+        console.log(`Result with x=2: ${expression.calc({ x: 2 })}`);
+        console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2})}`);
+    }
 }

--- a/evaluator.js
+++ b/evaluator.js
@@ -56,14 +56,17 @@ function evaluate(expression) {
 
     traverse(evaluate_tree, unknowns);
 
-    return variables => {
-        if (Object.keys(variables).length !== unknowns.length)
-            throw Error(`Incorrect number of values passed: should be ${unknowns.length} and is ${Object.keys(variables).length}`);
-        for (let v of unknowns)
-            if (!variables.hasOwnProperty(v))
-                throw Error(`Missing value for variable ${v}`);
+    return {
+        evaluate: variables => {
+            if (Object.keys(variables).length !== unknowns.length)
+                throw Error(`Incorrect number of values passed: should be ${unknowns.length} and is ${Object.keys(variables).length}`);
+            for (let v of unknowns)
+                if (!variables.hasOwnProperty(v))
+                    throw Error(`Missing value for variable ${v}`);
         
-        return evaluate_tree.fn(variables);
+            return evaluate_tree.fn(variables);
+        },
+        unknowns
     };
 }
 
@@ -74,17 +77,17 @@ if (!module.parent) {
     let expression = evaluate(str);
 
     console.log(`Expression: ${str}`);
-    console.log(`Result with x=2 and y=5: ${expression({ x: 2, y: 5 })}`);
+    console.log(`Result with x=2 and y=5: ${expression.evaluate({ x: 2, y: 5 })}`);
 
     str = "(-(-x + 5) / (-3 + y))";
     expression = evaluate(str);
 
     console.log(`Expression: ${str}`);
-    console.log(`Result with x=2 and y=5: ${expression({ x: 2, y: 5 })}`);
+    console.log(`Result with x=2 and y=5: ${expression.evaluate({ x: 2, y: 5 })}`);
 
     str = "+4(x + 3x)(-9 - x)";
     expression = evaluate(str);
 
     console.log(`Expression: ${str}`);
-    console.log(`Result with x=2: ${expression({ x: 2 })}`);
+    console.log(`Result with x=2: ${expression.evaluate({ x: 2 })}`);
 }

--- a/evaluator.js
+++ b/evaluator.js
@@ -9,6 +9,12 @@
  * that operates that specific node.
  * The `evaluate` function returns a function that takes the values of
  * unknowns present in the expression, and returns a numerical result.
+ *
+ * On the other hand, fastEvaluate does a similar job, but skips the
+ * generation of the evaluation tree and calculates the result directly.
+ * This solution may be faster when there is only one calculation to be
+ * done, whereas the normal evaluator should be faster when calculating
+ * multiple times the same expression.
  */
 
 const { lexer } = require('./lexer.js');

--- a/evaluator.js
+++ b/evaluator.js
@@ -15,38 +15,38 @@ const { lexer } = require('./lexer.js');
 const { syntax_check } = require('./syntax_check.js');
 const { parse } = require('./parse.js');
 
-function traverse(node) {
-    if (node.type === 'block') {
-        traverse(node.child[0]);
-        node.fn = variables => node.child[0].fn(variables);
-    } else if (node.type === 'unary_operator') {
-        traverse(node.child);
-        
-        if (node.operator === '+')
-            node.fn = vars => node.child.fn(vars);
-        else if (node.operator === '-')
-            node.fn = vars => -node.child.fn(vars);
-    } else if (node.type === 'binary_operator'){
-        traverse(node.left);
-        traverse(node.right);
-        
-        if (node.operator === '+')
-            node.fn = vars => node.left.fn(vars) + node.right.fn(vars);
-        else if (node.operator === '-')
-            node.fn = vars => node.left.fn(vars) - node.right.fn(vars);
-        else if (node.operator === '*')
-            node.fn = vars => node.left.fn(vars) * node.right.fn(vars);
-        else if (node.operator === '/')
-            node.fn = vars => node.left.fn(vars) / node.right.fn(vars);
-        else if (node.operator === '^')
-            node.fn = vars => node.left.fn(vars) ** node.right.fn(vars);
-    } else if (node.type === 'literal') {
-        node.fn = vars => parseInt(node.value, 10);
-    } else if (node.type === 'variable')
-        node.fn = vars => vars[node.name];
-}
-
 function evaluate(expression) {
+    function traverse(node) {
+        if (node.type === 'block') {
+            traverse(node.child[0]);
+            node.fn = variables => node.child[0].fn(variables);
+        } else if (node.type === 'unary_operator') {
+            traverse(node.child);
+            
+            if (node.operator === '+')
+                node.fn = vars => node.child.fn(vars);
+            else if (node.operator === '-')
+                node.fn = vars => -node.child.fn(vars);
+        } else if (node.type === 'binary_operator'){
+            traverse(node.left);
+            traverse(node.right);
+            
+            if (node.operator === '+')
+                node.fn = vars => node.left.fn(vars) + node.right.fn(vars);
+            else if (node.operator === '-')
+                node.fn = vars => node.left.fn(vars) - node.right.fn(vars);
+            else if (node.operator === '*')
+                node.fn = vars => node.left.fn(vars) * node.right.fn(vars);
+            else if (node.operator === '/')
+                node.fn = vars => node.left.fn(vars) / node.right.fn(vars);
+            else if (node.operator === '^')
+                node.fn = vars => node.left.fn(vars) ** node.right.fn(vars);
+        } else if (node.type === 'literal') {
+            node.fn = vars => parseInt(node.value, 10);
+        } else if (node.type === 'variable')
+            node.fn = vars => vars[node.name];
+    }
+
     let [tokens, unknowns] = lexer(expression);
     tokens = syntax_check(tokens);
     let parse_tree = parse(tokens);
@@ -70,7 +70,41 @@ function evaluate(expression) {
     };
 }
 
-module.exports = { evaluate };
+function fastEvaluate(expression, values) {
+    function traverse(node, values) {
+        if (node.type === 'block') return traverse(node.child[0], values);
+        else if (node.type === 'unary_operator') {
+            if (node.operator === '+') return traverse(node.child, values);
+            else if (node.operator === '-') return -traverse(node.child, values);
+        } else if (node.type === 'binary_operator') {
+            if (node.operator === '+')
+                return traverse(node.left, values) + traverse(node.right, values);
+            else if (node.operator === '-')
+                return traverse(node.left, values) - traverse(node.right, values);
+            else if (node.operator === '*')
+                return traverse(node.left, values) * traverse(node.right, values);
+            else if (node.operator === '/')
+                return traverse(node.left, values) / traverse(node.right, values);
+        } else if (node.type === 'literal') 
+            return parseInt(node.value, 10);
+        else if (node.type === 'variable') return values[node.name];
+    }
+
+    let [tokens, unknowns] = lexer(expression);
+    tokens = syntax_check(tokens);
+    let parse_tree = parse(tokens);
+
+    // Checking for correct values passed
+    if (Object.keys(values).length !== unknowns.length)
+        throw Error(`Incorrect number of values passed: should be ${unknowns.length} and is ${Object.keys(values).length}`);
+    for (let v of unknowns)
+        if (!values.hasOwnProperty(v))
+            throw Error(`Missing value for variable ${v}`);
+
+    return traverse(parse_tree, values);
+}
+
+module.exports = { evaluate, fastEvaluate };
 
 if (!module.parent) {
     let str = "((x + 5) / (3 - y))";
@@ -78,16 +112,19 @@ if (!module.parent) {
 
     console.log(`Expression: ${str}`);
     console.log(`Result with x=2 and y=5: ${expression.evaluate({ x: 2, y: 5 })}`);
+    console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2, y: 5 })}`);
 
     str = "(-(-x + 5) / (-3 + y))";
     expression = evaluate(str);
 
     console.log(`Expression: ${str}`);
     console.log(`Result with x=2 and y=5: ${expression.evaluate({ x: 2, y: 5 })}`);
+    console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2, y: 5 })}`);
 
     str = "+4(x + 3x)(-9 - x)";
     expression = evaluate(str);
 
     console.log(`Expression: ${str}`);
     console.log(`Result with x=2: ${expression.evaluate({ x: 2 })}`);
+    console.log(`Fast evaluation: ${fastEvaluate(str, { x: 2})}`);
 }

--- a/functions_time.js
+++ b/functions_time.js
@@ -1,0 +1,12 @@
+function functionsTime(fn, times, ...args) {
+    let start, end;
+
+    start = new Date().getTime();
+    for (let i = 0; i < times; i++)
+        fn(...args);
+    end = new Date().getTime();
+
+    return end - start;
+}
+
+module.exports = { functionsTime };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neiras-expression-parser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A small module to parse and evaluate user-provided mathematical expressions with or without unknowns",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The implementation of the fastEvaluate function is very similar to the normal evaluate, but it allows to compare the two different algorithmic approaches and provides an alternative for different uses. The new function skips the generation of the evaluation tree, and focuses on calculating the result directly. This has the advantage of having less memory allocated for the functions of the evaluation tree, and is overall faster than the combination of generating the evaluation tree and using it. However, when calculating the same equation repeatedly, such as for plotting a function, the fast evaluation fall behind, because the time taken to calculate with an already generated evaluation tree is by far less than it takes to calculate from the bare expression.
Here are the results that back this logic, given by the performance analysis implemented in the same evaluator module. Please mind that the computer this was tested on is kinda slow, and feel free to replicate the tests yourself.

| Repetitions | Generating the evaluation tree | Calculating with tree | Fast calculation |
| -------- | -------- | -------- | ---------- |
| 10,000 | 70ms | 5ms | 36ms |
| 100,000 | 388ms | 13ms | 318ms |
| 1,000,000 | 3608ms | 88ms | 3137ms |